### PR TITLE
Added accessibility fixes for sr-only labels

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -314,7 +314,7 @@
                     <form class="text-center flex-wrap px-lg-5" id="requester-form">
                       <div class="form-row">
                         <div class="form-group mb-3 mb-md-2 col-6">
-                          <label for="first-name" class="sr-only">First Name</label>
+                          <label for="requester-first-name" class="sr-only">First Name</label>
                           <input
                             required
                             maxlength="64"
@@ -325,7 +325,7 @@
                           />
                         </div>
                         <div class="form-group mb-3 mb-md-2 col-6">
-                          <label for="last-name" class="sr-only">Last Name</label>
+                          <label for="requester-last-name" class="sr-only">Last Name</label>
                           <input
                             required
                             maxlength="64"
@@ -337,7 +337,7 @@
                         </div>
                       </div>
                       <div class="form-group mb-3 mb-md-2">
-                        <label for="phone" class="sr-only">Phone Number</label>
+                        <label for="requester-phone" class="sr-only">Phone Number</label>
                         <input
                           required
                           maxlength="16"
@@ -348,7 +348,7 @@
                         />
                       </div>
                       <div class="form-group mb-3 mb-md-2">
-                        <label for="address" class="sr-only">Street Address</label>
+                        <label for="requester-address" class="sr-only">Street Address</label>
                         <input
                           required
                           type="text"
@@ -359,7 +359,7 @@
                         />
                       </div>
                       <div class="form-group mb-3 mb-md-2">
-                        <label for="phone" class="sr-only">Email</label>
+                        <label for="requester-email" class="sr-only">Email</label>
                         <input
                           type="email"
                           maxlength="256"
@@ -369,7 +369,9 @@
                         />
                       </div>
                       <div class="form-group mb-3 mb-md-2">
-                        <label for="shopping-list" class="sr-only">Enter shopping list here.</label>
+                        <label for="requester-shopping-list" class="sr-only"
+                          >Enter shopping list here.</label
+                        >
                         <textarea
                           required
                           maxlength="1024"
@@ -469,7 +471,7 @@
                     <form class="text-center flex-wrap px-lg-5" id="volunteer-form">
                       <div class="form-row">
                         <div class="form-group mb-3 mb-md-2 col-6">
-                          <label for="first-name" class="sr-only">First Name</label>
+                          <label for="volunteer-first-name" class="sr-only">First Name</label>
                           <input
                             required
                             type="text"
@@ -480,7 +482,7 @@
                           />
                         </div>
                         <div class="form-group mb-3 mb-md-2 col-6">
-                          <label for="last-name" class="sr-only">Last Name</label>
+                          <label for="volunteer-last-name" class="sr-only">Last Name</label>
                           <input
                             required
                             type="text"
@@ -492,7 +494,7 @@
                         </div>
                       </div>
                       <div class="form-group mb-3 mb-md-2">
-                        <label for="phone" class="sr-only">Phone Number</label>
+                        <label for="volunteer-phone" class="sr-only">Phone Number</label>
                         <input
                           required
                           type="tel"
@@ -503,7 +505,7 @@
                         />
                       </div>
                       <div class="form-group mb-3 mb-md-2">
-                        <label for="address" class="sr-only">Street Address</label>
+                        <label for="volunteer-address" class="sr-only">Street Address</label>
                         <input
                           required
                           type="text"
@@ -514,7 +516,7 @@
                         />
                       </div>
                       <div class="form-group mb-3 mb-md-2">
-                        <label for="phone" class="sr-only">Email</label>
+                        <label for="volunteer-email" class="sr-only">Email</label>
                         <input
                           required
                           type="email"


### PR DESCRIPTION
whenever you have a label and an associated input, the `for` attribute of the label has to match the `id` of the input. We had a bunch of mismatches which would affect users with screen readers