### PR TITLE
checked if contactData has hasCar key before adding it to avo info

### DIFF
--- a/functions/dbTriggers.js
+++ b/functions/dbTriggers.js
@@ -177,7 +177,7 @@ function getRequestConfirmationToDeliverEaseMailOptions(snapshot) {
 function getAvochatoContactInfo(snapshot, tags) {
   const contactData = snapshot.val();
   const uuidTag = tags.toLowerCase();
-  return {
+  const info = {
     auth_id: functions.config().apikeys.avochatoid,
     auth_secret: functions.config().apikeys.avochatosecret,
     contacts: [
@@ -187,11 +187,14 @@ function getAvochatoContactInfo(snapshot, tags) {
         email: contactData.email || '',
         tags: tags,
         [`${uuidTag}_uuid`]: `${snapshot.key}`,
-        has_car: contactData.hasCar.toString(),
         language: contactData.language.join(', '),
       },
     ],
   };
+  if ('hasCar' in contactData) {
+    info.contacts[0].has_car = contactData.hasCar.toString();
+  }
+  return info;
 }
 
 function getRequestConfirmationToRequesterMailOptions(snapshot) {


### PR DESCRIPTION
this was causing new requests to not successfully complete the cloud function trigger because it was trying to add hasCar->toString() to requesters avo info which caused an error.

trace:
`
at getAvochatoContactInfo (/workspace/dbTriggers.js:190:37)     at exports.requesterPostProcess.functions.database.ref.onCreate (/workspace/dbTriggers.js:46:40)     at cloudFunction (/workspace/node_modules/firebase-functions/lib/cloud-functions.js:131:23)     at Promise.resolve.then (/layers/google.nodejs.functions-framework/functions-framework/node_modules/@google-cloud/functions-framework/build/src/invoker.js:330:28)     at process._tickCallback (internal/process/next_tick.js:68:7) |  
-- | --
`